### PR TITLE
Updated for accurate ng usage to allow for proxying and auto-reloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ https://medium.com/@juliapassynkova/angular-springboot-jwt-integration-p-1-800a3
 
 ## Development server
 
-Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
+Run `ng start` for a dev server. Navigate to `http://0.0.0.0:4200/`. The app will automatically reload if you change any of the source files.
 
 ## Code scaffolding
 


### PR DESCRIPTION
The usage of  `ng serve` didn't correctly proxy requests. Also, page didn't automatically refresh on update. Using `ng start` allows both to occur naturally.